### PR TITLE
add ECDH instruction (NIP-44 / EIP-1581 paths only)

### DIFF
--- a/src/main/java/im/status/keycard/KeycardApplet.java
+++ b/src/main/java/im/status/keycard/KeycardApplet.java
@@ -1296,11 +1296,11 @@ public class KeycardApplet extends Applet {
       ISOException.throwIt(ISO7816.SW_WRONG_DATA);
     }
 
-    updateDerivationPath(apduBuffer, Crypto.KEY_PUB_SIZE, (short) (len - Crypto.KEY_PUB_SIZE));
-
     if (!(pin.isValidated() && masterPrivate.isInitialized())) {
       ISOException.throwIt(ISO7816.SW_CONDITIONS_NOT_SATISFIED);
     }
+
+    updateDerivationPath(apduBuffer, Crypto.KEY_PUB_SIZE, (short) (len - Crypto.KEY_PUB_SIZE));
 
     if (!(isNIP44() || isEIP1581())) {
       ISOException.throwIt(ISO7816.SW_CONDITIONS_NOT_SATISFIED);

--- a/src/main/java/im/status/keycard/KeycardApplet.java
+++ b/src/main/java/im/status/keycard/KeycardApplet.java
@@ -31,6 +31,7 @@ public class KeycardApplet extends Applet {
   static final byte INS_EXPORT_KEY = (byte) 0xC2;
   static final byte INS_EXPORT_LEE = (byte) 0xC3;
   static final byte INS_EXPORT_BIP85 = (byte) 0xC4;
+  static final byte INS_ECDH = (byte) 0xC5;
   static final byte INS_GET_DATA = (byte) 0xCA;
   static final byte INS_STORE_DATA = (byte) 0xE2;
   static final byte INS_GET_CHALLENGE = (byte) 0x84;
@@ -82,6 +83,10 @@ public class KeycardApplet extends Applet {
   static final byte EXPORT_KEY_P2_PUBLIC_ONLY = 0x01;
   static final byte EXPORT_KEY_P2_EXTENDED_PUBLIC = 0x02;
 
+  static final byte ECDH_P2_RAW_SECRET = 0x00;
+
+  static final byte UNCOMPRESSED_POINT_TAG = 0x04;
+
   static final byte STORE_DATA_P1_PUBLIC = 0x00;
   static final byte STORE_DATA_P1_NDEF = 0x01;
   static final byte STORE_DATA_P1_CASH = 0x02;
@@ -121,6 +126,7 @@ public class KeycardApplet extends Applet {
 
   static final byte[] EIP_1581_PREFIX = { (byte) 0x80, 0x00, 0x00, 0x2B, (byte) 0x80, 0x00, 0x00, 0x3C, (byte) 0x80, 0x00, 0x06, 0x2D};
   static final byte[] BIP85_PREFIX = { (byte) 0x84, (byte) 0xFD, (byte) 0x1D, (byte) 0x48 };
+  static final byte[] NIP44_PREFIX = { (byte) 0x80, 0x00, 0x00, 0x2C, (byte) 0x80, 0x00, 0x04, (byte) 0xD5 };
 
   private static final byte SEED_BIP32 = 0x00;
   private static final byte SEED_LEE = 0x01;
@@ -320,6 +326,9 @@ public class KeycardApplet extends Applet {
         return;
       case INS_EXPORT_BIP85:
         exportBIP85(apdu);
+        break;
+      case INS_ECDH:
+        ecdh(apdu);
         break;
       default:
         ISOException.throwIt(ISO7816.SW_INS_NOT_SUPPORTED);
@@ -1263,6 +1272,57 @@ public class KeycardApplet extends Applet {
   }
 
   /**
+   * Processes the ECDH command. Requires an open secure channel and the PIN to be verified. Computes an EC-DH
+   * key agreement between the key derived at the given path and the given peer public key, returning the
+   * x-coordinate of the resulting point (32 bytes). The data field must contain the peer public key as an
+   * uncompressed point (0x04 || X || Y, 65 bytes) followed by the derivation path (4 bytes per component,
+   * big-endian). Derivation is only permitted under the m/44'/1237' (NIP-44) and m/43'/60'/1581' (EIP-1581)
+   * prefixes, at a depth of at least 5 components; any other path is refused. The returned value is a raw
+   * shared secret, not an encryption key: protocols are expected to run it through a KDF host-side (NIP-44
+   * uses HKDF-extract with salt "nip44-v2").
+   *
+   * @param apdu the JCRE-owned APDU object.
+   */
+  private void ecdh(APDU apdu) {
+    byte[] apduBuffer = apdu.getBuffer();
+
+    if (apduBuffer[OFFSET_P1] != SIGN_P1_DERIVE || apduBuffer[OFFSET_P2] != ECDH_P2_RAW_SECRET) {
+      ISOException.throwIt(ISO7816.SW_WRONG_P1P2);
+    }
+
+    short len = (short) (apduBuffer[ISO7816.OFFSET_LC] & (short) 0xFF);
+
+    if ((len < (short) (Crypto.KEY_PUB_SIZE + 4)) || apduBuffer[OFFSET_CDATA] != UNCOMPRESSED_POINT_TAG) {
+      ISOException.throwIt(ISO7816.SW_WRONG_DATA);
+    }
+
+    updateDerivationPath(apduBuffer, Crypto.KEY_PUB_SIZE, (short) (len - Crypto.KEY_PUB_SIZE));
+
+    if (!(pin.isValidated() && masterPrivate.isInitialized())) {
+      ISOException.throwIt(ISO7816.SW_CONDITIONS_NOT_SATISFIED);
+    }
+
+    if (!(isNIP44() || isEIP1581())) {
+      ISOException.throwIt(ISO7816.SW_CONDITIONS_NOT_SATISFIED);
+    }
+
+    doDerive(apduBuffer, Crypto.KEY_PUB_SIZE);
+    secp256k1.tmpECPrivateKey.setS(derivationOutput, (short) 0, Crypto.KEY_SECRET_SIZE);
+
+    short outLen = 0;
+    try {
+      crypto.ecdh.init(secp256k1.tmpECPrivateKey);
+      outLen = crypto.ecdh.generateSecret(apduBuffer, OFFSET_CDATA, Crypto.KEY_PUB_SIZE, crypto.scratch, (short) 0);
+    } catch (CryptoException e) {
+      ISOException.throwIt(ISO7816.SW_WRONG_DATA);
+    }
+
+    Util.arrayCopyNonAtomic(crypto.scratch, (short) 0, apduBuffer, OFFSET_CDATA, outLen);
+
+    secureChannel.respond(apdu, outLen, ISO7816.SW_NO_ERROR);
+  }
+
+  /**
    * Processes the GET DATA command.
    *
    * @param apdu the JCRE-owned APDU object.
@@ -1390,6 +1450,10 @@ public class KeycardApplet extends Applet {
     }
 
     return true;
+  }
+
+  private boolean isNIP44() {
+    return (tmpPath[0] >= (short)(((short) NIP44_PREFIX.length) + 12)) && (Util.arrayCompare(NIP44_PREFIX, (short) 0, tmpPath, (short) 1, (short) NIP44_PREFIX.length) == 0);
   }
 
   /**

--- a/src/test/java/im/status/keycard/KeycardTest.java
+++ b/src/test/java/im/status/keycard/KeycardTest.java
@@ -40,6 +40,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.security.*;
 
+import org.bouncycastle.jce.interfaces.ECPrivateKey;
 import org.bouncycastle.jce.interfaces.ECPublicKey;
 
 import java.util.Arrays;
@@ -1075,7 +1076,81 @@ public class KeycardTest {
     response = cmdSet.exportBIP85(64, new KeyPath("m/83696968'/0'/0'").getData());
     assertEquals(0x9000, response.getSw());
     assertArrayEquals(expectedData, response.getData());
-  }  
+  }
+
+  @Test
+  @DisplayName("ECDH")
+  void ecdhTest() throws Exception {
+    APDUResponse response;
+    String nip44Path = "m/44'/1237'/0'/0/0";
+    String eip1581Path = "m/43'/60'/1581'/0'/0";
+    ECParameterSpec ecSpec = ECNamedCurveTable.getParameterSpec("secp256k1");
+    byte[] goodPoint = ecSpec.getG().getEncoded(false);
+    byte[] goodPath = new KeyPath(nip44Path).getData();
+    byte[] goodData = cat(goodPoint, goodPath);
+
+    // Security condition violation: SecureChannel not open
+    assertEquals(0x6985, ecdhWithPath(nip44Path).getSw());
+
+    cmdSet.autoOpenSecureChannel();
+
+    // Security condition violation: PIN not verified
+    assertEquals(0x6985, ecdhWithPath(nip44Path).getSw());
+
+    response = cmdSet.verifyPIN("000000");
+    assertEquals(0x9000, response.getSw());
+
+    // wrong P1 / wrong P2
+    assertEquals(0x6B00, cmdSet.ecdh(0, 0, goodData).getSw());
+    assertEquals(0x6B00, cmdSet.ecdh(KeycardApplet.SIGN_P1_DERIVE, 1, goodData).getSw());
+
+    response = cmdSet.loadKey(new BIP32KeyPair(Hex.decode("3f15e5d852dc2e9ba5e9fe189a8dd2e1547badef5b563bbe6579fc6807d80ed9"), Hex.decode("1b67969d1ec69bdfeeae43213da8460ba34b92d0788c8f7bfcfa44906e8a589c"), null));
+    assertEquals(0x9000, response.getSw());
+
+    assertEcdhAgrees(nip44Path);   // NIP-44 branch
+    assertEcdhAgrees(eip1581Path); // EIP-1581 branch
+
+    // pinned vector: fixed master (repo test key), peer priv = 2, path m/44'/1237'/0'/0/0.
+    // expected value computed with an independent implementation
+    byte[] fixedPeerPub = Hex.decode("04c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a");
+    response = cmdSet.ecdh(cat(fixedPeerPub, new KeyPath(nip44Path).getData()));
+    assertEquals(0x9000, response.getSw());
+    assertArrayEquals(Hex.decode("61a56a403a5be9a83ae4ba33d580611db5a57586f999a134daba516929905ec6"), response.getData());
+    // pinned vector, EIP-1581 branch: same master + peer, path m/43'/60'/1581'/0'/0
+    response = cmdSet.ecdh(cat(fixedPeerPub, new KeyPath(eip1581Path).getData()));
+    assertEquals(0x9000, response.getSw());
+    assertArrayEquals(Hex.decode("513fbb10f54297573f05085f9f80b7d8418c4f6805960051667916b45c68e6d4"), response.getData());
+
+    // rejected: wallet branch
+    assertEquals(0x6985, ecdhWithPath("m/44'/60'/0'/0/0").getSw());
+
+    // rejected: allowed prefixes but one level short
+    assertEquals(0x6985, ecdhWithPath("m/44'/1237'/0'/0").getSw());
+    assertEquals(0x6985, ecdhWithPath("m/43'/60'/1581'/0'").getSw());
+
+    // ------ malformed input ------
+    // truncated point: leading 0x04 survives, surplus path byte breaks the %4 alignment
+    assertEquals(0x6A80, cmdSet.ecdh(cat(Arrays.copyOf(goodPoint, 64), goodPath)).getSw());
+
+    // prefix not 0x04
+    byte[] badPrefix = goodPoint.clone();
+    badPrefix[0] = 0x02;
+    assertEquals(0x6A80, cmdSet.ecdh(cat(badPrefix, goodPath)).getSw());
+
+    // point not on the curve
+    byte[] offCurve = goodPoint.clone();
+    offCurve[64] ^= 1;
+    assertEquals(0x6A80, cmdSet.ecdh(cat(offCurve, goodPath)).getSw());
+
+    // path length not a multiple of 4
+    assertEquals(0x6A80, cmdSet.ecdh(cat(goodPoint, Arrays.copyOf(goodPath, 19))).getSw());
+
+    // point only, no path
+    assertEquals(0x6A80, cmdSet.ecdh(goodPoint).getSw());
+
+    // path deeper than KEY_PATH_MAX_DEPTH (11 levels, raw — SDK's KeyPath refuses to build this)
+    assertEquals(0x6A80, cmdSet.ecdh(cat(goodPoint, new byte[44])).getSw());
+  }
 
   @Test
   @DisplayName("STORE/GET DATA")
@@ -1534,5 +1609,55 @@ public class KeycardTest {
 
   private void verifyKeyUID(byte[] keyUID, byte[] pubKey) {
     assertArrayEquals(sha256(pubKey), keyUID);
+  }
+
+  private APDUResponse ecdhWithPath(String keyPath) throws Exception {
+    byte[] path = new KeyPath(keyPath).getData();
+
+    KeyPair peer = keypairGenerator().generateKeyPair();
+    byte[] peerPub = ((ECPublicKey) peer.getPublic()).getQ().getEncoded(false);
+
+    byte[] data = new byte[peerPub.length + path.length];
+    System.arraycopy(peerPub, 0, data, 0, peerPub.length);
+    System.arraycopy(path, 0, data, peerPub.length, path.length);
+
+    return cmdSet.ecdh(data);
+  }
+
+  private void assertEcdhAgrees(String keyPath) throws Exception {
+    APDUResponse response;
+
+    byte[] path = new KeyPath(keyPath).getData();
+
+    // A: card's public key at that path
+    response = cmdSet.exportKey(path, KeycardApplet.DERIVE_P1_SOURCE_MASTER, false, true);
+    assertEquals(0x9000, response.getSw());
+    byte[] cardPub = BIP32KeyPair.fromTLV(response.getData()).getPublicKey();
+
+    // B: host keypair
+    KeyPair peer = keypairGenerator().generateKeyPair();
+    BigInteger peerPriv = ((ECPrivateKey) peer.getPrivate()).getD();
+    byte[] peerPub = ((ECPublicKey) peer.getPublic()).getQ().getEncoded(false);
+
+    // card side: A_priv x B_pub
+    byte[] data = new byte[peerPub.length + path.length];
+    System.arraycopy(peerPub, 0, data, 0, peerPub.length);
+    System.arraycopy(path, 0, data, peerPub.length, path.length);
+
+    response = cmdSet.ecdh(data);
+    assertEquals(0x9000, response.getSw());
+
+    // host side: B_priv x A_pub
+    ECParameterSpec ecSpec = ECNamedCurveTable.getParameterSpec("secp256k1");
+    byte[] expected = ecSpec.getCurve().decodePoint(cardPub).multiply(peerPriv).normalize().getAffineXCoord().getEncoded();
+
+    assertArrayEquals(expected, response.getData());
+  }
+
+  private byte[] cat(byte[] a, byte[] b) {
+    byte[] out = new byte[a.length + b.length];
+    System.arraycopy(a, 0, out, 0, a.length);
+    System.arraycopy(b, 0, out, a.length, b.length);
+    return out;
   }
 }

--- a/src/test/java/im/status/keycard/TestKeycardCommandSet.java
+++ b/src/test/java/im/status/keycard/TestKeycardCommandSet.java
@@ -118,4 +118,12 @@ public class TestKeycardCommandSet extends KeycardCommandSet {
   public APDUResponse exportBIP85(int p1, byte[] data) throws IOException {
     return this.getSecureChannel().transmit(channel, this.getSecureChannel().protectedCommand(0x80, KeycardApplet.INS_EXPORT_BIP85, p1, 0, data));
   }
+
+  public APDUResponse ecdh(int p1, int p2, byte[] data) throws IOException {
+    return this.getSecureChannel().transmit(channel, this.getSecureChannel().protectedCommand(0x80, KeycardApplet.INS_ECDH, p1, p2, data));
+  }
+
+  public APDUResponse ecdh(byte[] data) throws IOException {
+    return ecdh(KeycardApplet.SIGN_P1_DERIVE, KeycardApplet.ECDH_P2_RAW_SECRET, data);
+  }
 }


### PR DESCRIPTION
Adds one instruction, `INS_ECDH` (`0xC5`): EC-DH key agreement between a key derived at a BIP-32 path and a caller-supplied public key, returning the raw 32-byte x-coordinate of the shared point.

## Motivation

The applet can sign but cannot perform key agreement, so every "decrypt to me" scheme currently has to export the private key and do ECDH on the host. The immediate case is Nostr: 5 of the 7 methods a NIP-55 signer must implement are encrypt/decrypt (NIP-44 conversation keys are HKDF over the ECDH shared x; legacy NIP-04 uses the bare x
directly). The same gap blocks ECIES-style sealed-to-my-key schemes generally.

The primitive is already on the card: `SecureChannelV2` runs the identical `ALG_EC_SVDP_DH_PLAIN` init/generateSecret on every session open. This PR exposes it behind the same conditions as SIGN, restricted by derivation path.

## APDU

| Field | Value |
|---|---|
| CLA | `0x80` (wrapped in the secure channel like every command) |
| INS | `0xC5` |
| P1 | `0x01` (derive, same convention as SIGN) — only value accepted |
| P2 | `0x00` = raw shared secret x-coordinate; other values reserved |
| Data | 65-byte uncompressed peer key `04 ‖ X ‖ Y`, then the path (4 bytes/component, BE) |
| Response | 32 bytes, shared x — bare, fixed length |

Requires an open secure channel and verified PIN. 
Errors: 
- `0x6B00` bad P1/P2
- `0x6A80` malformed input (short Lc, prefix != `04`, path not 4-aligned/too deep, point not on the curve)
- `0x6985` PIN/no key/path outside the permitted prefixes.

## Path restriction

Only two branches are permitted, both requiring a full 5-level path:

- `m/44'/1237'` (NIP-06 Nostr identity, SLIP-44 coin 1237) — new capability, narrow: agreement results only, never the scalar
- `m/43'/60'/1581'` — costs nothing: private keys under EIP-1581 are already exportable via EXPORT KEY, so ECDH there grants strictly less

Wallet paths (`m/44'/60'`, …) are unreachable by this instruction.

## Security notes

- Peer point validity is enforced by the `0x04`/length checks plus the platform's point validation (`CryptoException` → `0x6A80`), the same pattern `SecureChannelV2.openSecureChannel` relies on. secp256k1 cofactor 1: no small
  subgroups; full uncompressed input: no twist points.
- The response is a raw shared secret, not an encryption key. Protocols run it through a KDF host-side (NIP-44: HKDF-extract, salt `"nip44-v2"`). Stated in the method javadoc.
- The card stores nothing; output is a deterministic function of the inputs.

## Footprint

No new persistent objects; reuses `crypto.ecdh`, `secp256k1.tmpECPrivateKey` and the existing scratch. The additions to card memory are the instruction's bytecode, the 8-byte `NIP44_PREFIX` constant and two byte constants.

## Tests

`ecdhTest` covers: 
- agreement vs BouncyCastle on both branches; two pinned vectors computed with an independent implementation (catches correlated derivation bugs)
- rejected wallet path
- both prefixes one level short
- no PIN
- outside the secure channel
- wrong P1/P2
- and malformed input (truncated point, bad prefix, off-curve point, misaligned path, missing path, 11-level path).

Full suite passes on a physical card (20/20). Not run on the simulator.

The exact host pipeline this enables (even-Y lift → card ECDH → HKDF-extract) reproduces all 35 official NIP-44 `get_conversation_key` test vectors.

## Follow-ups (not this PR)

- `keycard-sdk`: `ecdh(...)` command wrapper - optional `P2 = 0x01` mode returning the NIP-44 conversation key directly
  (`Crypto.hkdf` already exists on-card), so the raw secret never leaves the card. Happy to add if wanted